### PR TITLE
add -g|--ghosts FILE to allow independence from /etc/ghosts

### DIFF
--- a/ghosts
+++ b/ghosts
@@ -13,6 +13,11 @@ ghosts [OPTIONS] SYSTEMS
 
  -h, --help            Display full help
 
+=item B<-g>, B<--ghosts> CONFIG_FILE
+
+Uses the provided ghosts configuration file, instead of /etc/ghosts. This
+means /etc/ghosts will not be read at all.
+
 =head1 DESCRIPTION
 
 Parses the /etc/ghosts file for matching hosts.  The first word of each
@@ -48,6 +53,11 @@ The gsh(1) command can be used to run remote SSH connections to hosts.
 
 Displays this full help.
 
+=item B<-g>, B<--ghosts> CONFIG_FILE
+
+Uses the provided ghosts configuration file, instead of /etc/ghosts. This
+means /etc/ghosts will not be read at all.
+
 =back
 
 =cut
@@ -57,14 +67,17 @@ use Getopt::Long qw(:config no_ignore_case bundling require_order);
 use Pod::Usage;
 
 our $opt_help = 0;
+our $opt_ghosts = "";
 
-GetOptions("help|h") or pod2usage(-verbose => 0, -exitstatus => 1);
+GetOptions("help|h",
+           "ghosts|g=s") or pod2usage(-verbose => 0, -exitstatus => 1);
 
 pod2usage(-verbose => 2, -exitstatus => 0) if ($opt_help);
 
 pod2usage(-verbose => 0, -exitstatus => 1) if ($#ARGV<0);
 
-SystemManagement::Ghosts::Load();
+print $opt_ghosts, "\n";
+SystemManagement::Ghosts::Load($opt_ghosts);
 my @BACKBONES=SystemManagement::Ghosts::Expanded(@ARGV);
 
 # prints which machines match the argument list

--- a/ghosts
+++ b/ghosts
@@ -76,7 +76,6 @@ pod2usage(-verbose => 2, -exitstatus => 0) if ($opt_help);
 
 pod2usage(-verbose => 0, -exitstatus => 1) if ($#ARGV<0);
 
-print $opt_ghosts, "\n";
 SystemManagement::Ghosts::Load($opt_ghosts);
 my @BACKBONES=SystemManagement::Ghosts::Expanded(@ARGV);
 

--- a/gsh
+++ b/gsh
@@ -14,6 +14,7 @@ gsh [OPTIONS] SYSTEMS CMD...
 
  -h, --help            Display full help
  -d, --debug           Turn on exeuction debugging reports
+ -g, --ghosts          specific ghosts configuration file
  -h, --no-host-prefix  Does not prefix output lines with the host name
  -s, --show-commands   Displays the command before the output report
  -n, --open-stdin      Leaves stdin open when running (scary!)
@@ -78,6 +79,11 @@ are show as commands are executed and reaped.
 
 Turns off the prefixing of hostnames to the output reports.
 
+=item B<-g>, B<--ghosts> CONFIG_FILE
+
+Uses the provided ghosts configuration file, instead of /etc/ghosts. This
+means /etc/ghosts will not be read, at all.
+
 =item B<-s>, B<--show-command>
 
 Displays the command being run before the output report for each host.
@@ -116,6 +122,7 @@ Displays the version information and exits.
 
 our $opt_help = 0;
 our $opt_debug = 0;
+our $opt_ghosts = "";
 our $opt_no_host_prefix = 0;
 our $opt_show_command = 0;
 our $opt_open_stdin = 0;
@@ -126,6 +133,7 @@ our $opt_version = 0;
 
 GetOptions("help|h",
            "debug|d",
+           "ghosts|g=s",
            "no-host-prefix|p",
            "show-command|s",
            "open-stdin|n",
@@ -146,7 +154,7 @@ $cmd =~ s/'/'"'"'/g;			# quote any embedded single quotes
 
 pod2usage(-verbose => 0, -exitstatus => -1) if ($cmd eq "");
 
-SystemManagement::Ghosts::Load();
+SystemManagement::Ghosts::Load($opt_ghosts);
 my @BACKBONES=SystemManagement::Ghosts::Expanded($systype);
 
 my $TMP = tempdir( CLEANUP => 1 );


### PR DESCRIPTION
This is the change I commented on G+ -- it allows one to pass a configuration file as a parameter (-g or --ghosts). Reason: on some of the servers I base myself on I do not have root access.

The change is quite simple, since the code was pretty much already expecting it.
