### PR TITLE
User-define configuration

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3,6 +3,7 @@ README
 TODO
 LICENSE
 lib/SystemManagement/Ghosts.pm
+t/test_user_config.t
 gsh
 ghosts
 Makefile.PL

--- a/README
+++ b/README
@@ -22,6 +22,14 @@ Machine groups are run together with "+"s and "^"s as you see fit:
 
 	ghosts prod^intel
 
+The user can also define its own sets of machines in one of the following
+files (whichever is found first is the one in used):
+	$HOME/.ghosts
+	$HOME/.config/ghosts
+	$HOME/etc/ghosts
+The global and user-defined configurations are merged together by the
+"ghosts" command.
+
 The "ghosts" command just shows the resulting list.  "gsh" a group to run
 a command:
 

--- a/ghosts
+++ b/ghosts
@@ -71,6 +71,7 @@ pod2usage(-verbose => 2, -exitstatus => 0) if ($opt_help);
 pod2usage(-verbose => 0, -exitstatus => 1) if ($#ARGV<0);
 
 SystemManagement::Ghosts::Load($opt_ghosts);
+SystemManagement::Ghosts::Load(SystemManagement::Ghosts::UserConfig());
 my @BACKBONES=SystemManagement::Ghosts::Expanded(@ARGV);
 
 if (scalar @BACKBONES == 0) {

--- a/ghosts
+++ b/ghosts
@@ -76,10 +76,10 @@ my @BACKBONES=SystemManagement::Ghosts::Expanded(@ARGV);
 if (scalar @BACKBONES == 0) {
   print "Error: no hosts found\n";
   exit 3;
-} else {
-  # prints which machines match the argument list
-  print join(" ",@BACKBONES),"\n";
 }
+
+# prints which machines match the argument list
+print join(" ",@BACKBONES),"\n";
 
 =head1 PREREQUISITES
 

--- a/ghosts
+++ b/ghosts
@@ -57,7 +57,7 @@ means /etc/ghosts will not be read at all.
 
 =cut
 
-use SystemManagement::Ghosts;
+use SystemManagement::Ghosts qw( Load Expanded UserConfig );
 use Getopt::Long qw(:config no_ignore_case bundling require_order);
 use Pod::Usage;
 
@@ -71,9 +71,9 @@ pod2usage(-verbose => 2, -exitstatus => 0) if ($opt_help);
 
 pod2usage(-verbose => 0, -exitstatus => 1) if ($#ARGV<0);
 
-SystemManagement::Ghosts::Load($opt_ghosts);
-SystemManagement::Ghosts::Load(SystemManagement::Ghosts::UserConfig());
-my @BACKBONES=SystemManagement::Ghosts::Expanded(@ARGV);
+Load($opt_ghosts);
+Load(UserConfig());
+my @BACKBONES=Expanded(@ARGV);
 
 if (scalar @BACKBONES == 0) {
   print "Error: no hosts found\n";

--- a/ghosts
+++ b/ghosts
@@ -14,7 +14,8 @@ ghosts [OPTIONS] SYSTEMS
 
 =head1 DESCRIPTION
 
-Parses the /etc/ghosts file for matching hosts.  The first word of each
+Parses the /etc/ghosts and the $HOME/.ghosts files for matching hosts.
+The first word of each
 line is the "hostname", and each other word on the line represents that
 host's membership in a given group.  In the example below, there are two
 machines ("bilbo", "baggins") in the "prod" group, one ("tolkien") in the
@@ -93,7 +94,13 @@ I bet.
 
 =head1 FILES
 
-/etc/ghosts
+ - /etc/ghosts
+   System configuration.
+
+ - $HOME/.ghosts
+ - $HOME/.config/ghosts
+ - $HOME/etc/ghosts
+   User-defined configuration (only the first one found will be used).
 
 =head1 SEE ALSO
 

--- a/gsh
+++ b/gsh
@@ -55,7 +55,7 @@ use warnings;
 our $NAME="gsh";
 our $VERSION="1.1.0";
 
-use SystemManagement::Ghosts;
+use SystemManagement::Ghosts qw( Load Expanded UserConfig );
 use POSIX "sys_wait_h";
 use File::Temp qw/ tempdir /;
 use Getopt::Long qw(:config no_ignore_case bundling require_order);
@@ -153,8 +153,8 @@ $cmd =~ s/'/'"'"'/g;			# quote any embedded single quotes
 
 pod2usage(-verbose => 0, -exitstatus => -1) if ($cmd eq "");
 
-SystemManagement::Ghosts::Load($opt_ghosts);
-my @BACKBONES=SystemManagement::Ghosts::Expanded($systype);
+Load($opt_ghosts);
+my @BACKBONES=Expanded($systype);
 
 my $TMP = tempdir( CLEANUP => 1 );
 

--- a/gsh
+++ b/gsh
@@ -154,6 +154,7 @@ $cmd =~ s/'/'"'"'/g;			# quote any embedded single quotes
 pod2usage(-verbose => 0, -exitstatus => -1) if ($cmd eq "");
 
 Load($opt_ghosts);
+Load(UserConfig());
 my @BACKBONES=Expanded($systype);
 
 my $TMP = tempdir( CLEANUP => 1 );

--- a/lib/SystemManagement/Ghosts.pm
+++ b/lib/SystemManagement/Ghosts.pm
@@ -3,6 +3,7 @@ use warnings;
 use strict;
 
 my $GHOSTS_PATH="/etc/ghosts";
+my @GHOSTS_USER = ('$HOME/.ghosts', '$HOME/.config/ghosts', '$HOME/etc/ghosts');
 my @GHOSTS;    # all the lines of the ghosts file
 
 # loads the ghosts file into @sysadmin_ghosts
@@ -108,6 +109,18 @@ sub ParseGhosts {
 sub Expanded {
 	my(@type) = @_;
 	return ParseGhosts(0,@type);
+}
+
+# Find the user's GHOSTS file:
+# one of $HOME/.ghosts, $HOME/.config/ghosts, $HOME/etc/ghosts
+# whichever is found first.  If no file is found, then FALSE is returned.
+sub UserConfig {
+   my @GHOSTS_USER = ('/.ghosts', '/.config/ghosts', '/etc/ghosts');
+   my $HOME = $ENV{HOME};
+   foreach my $config (map { $HOME . $_ } @GHOSTS_USER) {
+      return $config if -e $config;
+   }
+   return '';
 }
 
 1;

--- a/lib/SystemManagement/Ghosts.pm
+++ b/lib/SystemManagement/Ghosts.pm
@@ -2,6 +2,10 @@ package SystemManagement::Ghosts;
 use warnings;
 use strict;
 
+use Exporter 'import';
+
+our @EXPORT_OK = qw( Load Expanded UserConfig );
+
 my $GHOSTS_PATH="/etc/ghosts";
 my @GHOSTS_USER = ('$HOME/.ghosts', '$HOME/.config/ghosts', '$HOME/etc/ghosts');
 my @GHOSTS;    # all the lines of the ghosts file

--- a/lib/SystemManagement/Ghosts.pm
+++ b/lib/SystemManagement/Ghosts.pm
@@ -70,7 +70,7 @@ sub ParseGhosts {
 #				warn "'$one_of_these' matched '$name' as '$repl'\n";
         			$one_of_these =~ s/:$name:/:$repl:/;
 			}
-				
+
 			# do expansion in "unwanted" list
         		if ($one_of_these =~ /:-$name:/) {
 				my @query = ParseGhosts($depth+1,$repl);
@@ -82,11 +82,11 @@ sub ParseGhosts {
 		}
 		else {
 			# we have a normal line
-	
+
             my @attr = split(' ',lc($line));# a list of attributes to match against
             #   which we put into an array normalized to lower case
             my $host = $attr[0];       # the first attribute is the host name
-	
+
 			my $wanted = 0;
     			foreach my $attr (@attr) { # iterate over attribute array
        		 		if (index(lc($one_of_these),":$attr:") >= 0) {

--- a/lib/SystemManagement/Ghosts.pm
+++ b/lib/SystemManagement/Ghosts.pm
@@ -12,7 +12,7 @@ sub Load {
 	my($line);
 	$file=$GHOSTS_PATH if (!$file || $file eq "");
 	open(GHOSTS_FILE,"<${file}") ||
-		warn("$0: Cannot open \"${file}\": $!\n");
+		return;		# don't worry if file is unreadable
 	while (<GHOSTS_FILE>) {
 		# kill blank lines
 		s/[ \t]*\n//;

--- a/t/test_user_config.t
+++ b/t/test_user_config.t
@@ -19,15 +19,15 @@ sub touch {
 $ENV{HOME} = tempdir( CLEANUP => 1 );
 my $HOME = $ENV{HOME};
 
-is	'', SystemManagement::Ghosts::UserConfig(), 'no user-config found';
+is	'', UserConfig(), 'no user-config found';
 
 touch "$HOME/etc/ghosts";
-is	"$HOME/etc/ghosts", SystemManagement::Ghosts::UserConfig(), 'must find $HOME/etc/ghosts file';
+is	"$HOME/etc/ghosts", UserConfig(), 'must find $HOME/etc/ghosts file';
 
 touch "$HOME/.config/ghosts";
-is	"$HOME/.config/ghosts", SystemManagement::Ghosts::UserConfig(), 'must find $HOME/.config/ghosts file';
+is	"$HOME/.config/ghosts", UserConfig(), 'must find $HOME/.config/ghosts file';
 
 touch "$HOME/.ghosts";
-is	"$HOME/.ghosts", SystemManagement::Ghosts::UserConfig(), 'must find $HOME/.ghosts file';
+is	"$HOME/.ghosts", UserConfig(), 'must find $HOME/.ghosts file';
 
 done_testing();

--- a/t/test_user_config.t
+++ b/t/test_user_config.t
@@ -1,0 +1,33 @@
+use warnings;
+use strict;
+
+use Test::More;
+use File::Path qw(make_path);
+use File::Temp qw(tempdir);
+use File::Basename qw(dirname);
+
+use SystemManagement::Ghosts qw(UserConfig);
+
+# utility function to easily create temporary files
+sub touch {
+   my $file = shift;
+   make_path(dirname($file));
+   open my $fh, '>', $file or die 'can\'t create temporary file';
+}
+
+# change $HOME to a temp dir
+$ENV{HOME} = tempdir( CLEANUP => 1 );
+my $HOME = $ENV{HOME};
+
+is	'', SystemManagement::Ghosts::UserConfig(), 'no user-config found';
+
+touch "$HOME/etc/ghosts";
+is	"$HOME/etc/ghosts", SystemManagement::Ghosts::UserConfig(), 'must find $HOME/etc/ghosts file';
+
+touch "$HOME/.config/ghosts";
+is	"$HOME/.config/ghosts", SystemManagement::Ghosts::UserConfig(), 'must find $HOME/.config/ghosts file';
+
+touch "$HOME/.ghosts";
+is	"$HOME/.ghosts", SystemManagement::Ghosts::UserConfig(), 'must find $HOME/.ghosts file';
+
+done_testing();


### PR DESCRIPTION
Let the program use both system-defined and user-defined configurations.  Merge both of them, if any is found.
