### PR TITLE
make output appear in columns 

### DIFF
--- a/gsh
+++ b/gsh
@@ -53,7 +53,7 @@ use strict;
 use warnings;
 
 our $NAME="gsh";
-our $VERSION="1.1.1";
+our $VERSION="1.1.0-ee";
 
 use FindBin;
 use lib "$FindBin::Bin/lib";
@@ -63,6 +63,7 @@ use POSIX "sys_wait_h";
 use File::Temp qw/ tempdir /;
 use Getopt::Long qw(:config no_ignore_case bundling require_order);
 use Pod::Usage;
+use List::Util qw(reduce);
 
 =head1 OPTIONS
 
@@ -193,6 +194,9 @@ my $ssh_args="";
 $ssh_args.=$opt_open_stdin ? "" : " -n";
 $ssh_args.=$opt_user ? " -l $opt_user" : "";
 
+# determine max length of all hostnames
+my $maxhostlen = length(reduce{ length($a) > length($b) ? $a : $b } @BACKBONES);
+
 # for each machine that matched the ghosts systype do the following:
 my $oldcmd = $cmd;
 foreach my $host (@BACKBONES) {
@@ -201,7 +205,7 @@ foreach my $host (@BACKBONES) {
 	$output{$host}="";
 
 	# make a column header for this machine if needed
-	$showlist{$host} = $opt_no_host_prefix ? "" : "$host:\t";
+	$showlist{$host} = $opt_no_host_prefix ? "" : "$host:  " . (" "x($maxhostlen - length($host)));
 
 #	push(@tried,$host);
 	# do the fork

--- a/gsh
+++ b/gsh
@@ -53,7 +53,10 @@ use strict;
 use warnings;
 
 our $NAME="gsh";
-our $VERSION="1.1.0";
+our $VERSION="1.1.1";
+
+use FindBin;
+use lib "$FindBin::Bin/lib";
 
 use SystemManagement::Ghosts;
 use POSIX "sys_wait_h";

--- a/gsh
+++ b/gsh
@@ -53,7 +53,7 @@ use strict;
 use warnings;
 
 our $NAME="gsh";
-our $VERSION="1.1.0-ee";
+our $VERSION="1.1.0";
 
 use FindBin;
 use lib "$FindBin::Bin/lib";


### PR DESCRIPTION
Minor change to format the output of the hostname so that all output appear in columns regardless of length of hostname - mostly for ease of comparison.

Also included another minor change to use FindBin to use local dir for lib for ease of development and so installation is not strictly necessary.
