### PR TITLE
fix double loading of /etc/ghosts if no -g nor user-specific ghosts

### DIFF
--- a/gsh
+++ b/gsh
@@ -157,8 +157,7 @@ $cmd =~ s/'/'"'"'/g;			# quote any embedded single quotes
 
 pod2usage(-verbose => 0, -exitstatus => -1) if ($cmd eq "");
 
-Load($opt_ghosts);
-Load(UserConfig());
+Load($opt_ghosts || UserConfig());
 my @BACKBONES=Expanded($systype);
 
 my $TMP = tempdir( CLEANUP => 1 );

--- a/lib/SystemManagement/Ghosts.pm
+++ b/lib/SystemManagement/Ghosts.pm
@@ -124,7 +124,7 @@ sub UserConfig {
    foreach my $config (map { $HOME . $_ } @GHOSTS_USER) {
       return $config if -e $config;
    }
-   return '';
+   return undef;
 }
 
 1;


### PR DESCRIPTION
When no `-g <file>` nor user-specific ghosts file (one of several options) are present, the default behavior was loading `/etc/ghosts` twice, which resulted in double entries.

This trivial fix ensures that only one config file is ever loaded.